### PR TITLE
Adding tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "private": true,
   "dependencies": {
     "@testing-library/react": "^12.1.4",
-    "@testing-library/user-event": "^13.5.0",
     "axios": "^0.26.1",
     "bootstrap": "^5.1.3",
     "react": "^17.0.2",
@@ -40,7 +39,9 @@
     ]
   },
   "devDependencies": {
+    "@testing-library/dom": "^8.16.0",
     "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/user-event": "^14.2.1",
     "prettier": "^2.6.2",
     "sass": "^1.50.0"
   }

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -45,4 +45,17 @@ describe("Header", () => {
     expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
+  test("When dark mode is enabled, the theme toggler displays the light mode icon and text", () => {
+    render(
+      <Router>
+        <Header darkThemeEnabled={true} />
+      </Router>
+    );
+
+    expect(screen.getByRole("button")).toHaveStyle(
+      `background-image: url(${lightModeIcon})`
+    );
+    expect(screen.getByText("Light mode")).toBeInTheDocument();
+  });
+
 });

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -58,4 +58,18 @@ describe("Header", () => {
     expect(screen.getByText("Light mode")).toBeInTheDocument();
   });
 
+  test("When light mode is enabled, the theme toggler displays the dark mode icon and text", () => {
+    render(
+      <Router>
+        <Header darkThemeEnabled={false} />
+      </Router>
+    );
+
+    expect(screen.getByRole("button")).toHaveStyle(
+      `background-image: url(${darkModeIcon})`
+    );
+    expect(screen.getByText("Dark mode")).toBeInTheDocument();
+  });
+});
+
 });

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -1,5 +1,6 @@
 import React from "react";
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import darkModeIcon from "./../../images/icon-dark-mode.svg";
 import lightModeIcon from "./../../images/icon-light-mode.svg";
@@ -30,6 +31,18 @@ describe("Header", () => {
 
     expect(screen.getByText("Where in the world?")).toBeInTheDocument();
     expect(screen.getByTestId("theme-toggler")).toBeInTheDocument();
+  });
+
+  test("Calls toggleTheme prop when 'Dark Mode' button is clicked.", async () => {
+    const handleClick = jest.fn();
+    render(
+      <Router>
+        <Header darkThemeEnabled={false} toggleTheme={handleClick} />
+      </Router>
+    );
+
+    await userEvent.click(screen.getByText("Dark mode"));
+    expect(handleClick).toHaveBeenCalledTimes(1);
   });
 
 });


### PR DESCRIPTION
Add test for `<Header />`'s toggler button:
- [x] Displays "Dark Mode" when the current theme is light
- [x] Displays "Light Mode" when the current theme is dark
- [x] The icon changes accordingly

Fixes #21
