### PR TITLE
Adding tests, `<Header />`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
   "devDependencies": {
     "@testing-library/dom": "^8.16.0",
     "@testing-library/jest-dom": "^5.16.4",
+    "@testing-library/react-hooks": "^8.0.1",
     "@testing-library/user-event": "^14.2.1",
     "prettier": "^2.6.2",
     "sass": "^1.50.0"

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,7 @@
 import countriesService from "./services/countries";
 import "./css/App.scss";
 import { useState, useEffect } from "react";
+import useThemeToggler from "./utils/hooks/useThemeToggler";
 import { Routes, Route, useSearchParams } from "react-router-dom";
 
 import Header from "./components/Header/Header";
@@ -27,46 +28,13 @@ function App() {
     fetchCountries();
   }, []);
 
-  /**
-   * Dark theme
-   */
-
-  // darkThemeEnabled stores the current system color scheme (true: dark, false: light)
-  const [darkThemeEnabled, setDarkThemeEnabled] = useState(
-    window.matchMedia("(prefers-color-scheme: dark)").matches
-  );
-  // Select the root element to toggle theme
-  const rootElement = document.querySelector(":root");
-
-  // At first, the app's default will be the current system color scheme (light or dark)
+  // /**
+  //  * Dark theme
+  //  */
+  const { darkThemeEnabled, applyTheme, handleThemeToggle } = useThemeToggler();
   useEffect(() => {
-    if (darkThemeEnabled) {
-      rootElement.classList.add("dark-theme");
-    }
-  });
-
-  // Checks whether the dark theme was enabled during a previous visit. If so, adds the class "dark-theme" to the root element.
-  useEffect(() => {
-    const hasEnabledDarkTheme = JSON.parse(
-      window.localStorage.getItem("darkThemeEnabled")
-    );
-    if (hasEnabledDarkTheme === true) {
-      rootElement.classList.add("dark-theme");
-    } else if (hasEnabledDarkTheme === false) {
-      // Otherwise, check whether the user has defined the light color scheme as their preference.
-      // hasEnabledDarkTheme is checked for strict equality since if the local storage was empty, it would be null
-      rootElement.classList.remove("dark-theme");
-    }
-  });
-
-  // The click handler for the theme toggle button
-  // It only changes the state, useEffect hook is responsible for toggling the CSS class
-  const handleThemeToggle = () => {
-    // Toggle the current boolean
-    setDarkThemeEnabled(!darkThemeEnabled);
-    // Store the new value in the local storage
-    window.localStorage.setItem("darkThemeEnabled", !darkThemeEnabled);
-  };
+    applyTheme();
+  }, [darkThemeEnabled]);
 
   /**
    * Search state

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -85,4 +85,13 @@ describe("useThemeToggler hook ", () => {
 
     expect(result.current.darkThemeEnabled).toBe(false);
   });
+  test("useThemeToggler hook enables dark theme", () => {
+    const { result } = renderHook(() => useThemeToggler(false));
+
+    act(() => {
+      result.current.handleThemeToggle();
+    });
+
+    expect(result.current.darkThemeEnabled).toBe(true);
+  });
 });

--- a/src/components/Header/Header.test.js
+++ b/src/components/Header/Header.test.js
@@ -5,6 +5,9 @@ import "@testing-library/jest-dom";
 import darkModeIcon from "./../../images/icon-dark-mode.svg";
 import lightModeIcon from "./../../images/icon-light-mode.svg";
 
+import { renderHook, act } from "@testing-library/react-hooks";
+import useThemeToggler from "../../utils/hooks/useThemeToggler";
+
 import { BrowserRouter as Router } from "react-router-dom";
 
 import Header from "./Header";
@@ -72,4 +75,14 @@ describe("Header", () => {
   });
 });
 
+describe("useThemeToggler hook ", () => {
+  test("useThemeToggler hook disables dark theme", () => {
+    const { result } = renderHook(() => useThemeToggler(true));
+
+    act(() => {
+      result.current.handleThemeToggle();
+    });
+
+    expect(result.current.darkThemeEnabled).toBe(false);
+  });
 });

--- a/src/utils/hooks/useThemeToggler.js
+++ b/src/utils/hooks/useThemeToggler.js
@@ -1,0 +1,76 @@
+import { useState } from "react";
+
+/**
+ * Dark theme
+ */
+export default function useThemeToggler(
+  initialState = window.matchMedia("(prefers-color-scheme: dark)").matches ||
+    false
+) {
+  /**
+   * darkThemeEnabled stores the current system color scheme by default (true: dark, false: light).
+   */
+  const [darkThemeEnabled, setDarkThemeEnabled] = useState(initialState);
+
+  /**
+   * Utility to get the theme enabled by the user from localStorage.
+   */
+  function getChosenTheme() {
+    return JSON.parse(window.localStorage.getItem("darkThemeEnabled"));
+  }
+
+  /**
+   * Utility to set the theme enabled by the user from localStorage.
+   */
+  function setChosenTheme(themeChosen) {
+    window.localStorage.setItem(
+      "darkThemeEnabled",
+      JSON.stringify(themeChosen)
+    );
+  }
+
+  /**
+   * Utility to add or remove the 'dark-theme' class on body element to change the theme.
+   */
+  function applyClasses(newTheme) {
+    const bodyElement = document.querySelector("body");
+
+    // Since we don't know what the system preference of the user is, use .add or .remove depending of the value of wantDark. Neither method does anything if its call doesn't change anything.
+
+    if (newTheme) {
+      bodyElement.classList.add("dark-theme");
+    } else {
+      bodyElement.classList.remove("dark-theme");
+    }
+  }
+
+  /**
+   * useEffect function to match the app theme with the theme set by the user.
+   */
+  function applyTheme() {
+    // Get the darkThemeEnabled value from local storage
+    const chosenTheme = getChosenTheme();
+    if (chosenTheme === null) {
+      // If there is no value in localStorage we use the value from the state, which will be the user's system theme.
+      applyClasses(darkThemeEnabled);
+    } else if (chosenTheme === true || chosenTheme === false) {
+      // Otherwise darkThemeEnabled in localStorage is either true or false. We use that value to apply the correct class to the body and set the theme.
+      applyClasses(chosenTheme);
+    }
+  }
+
+  /**
+   * Click event handler to toggle the theme.
+   */
+  function handleThemeToggle() {
+    setDarkThemeEnabled(!darkThemeEnabled);
+    setChosenTheme(!darkThemeEnabled);
+    applyClasses(!darkThemeEnabled);
+  }
+
+  return {
+    darkThemeEnabled,
+    applyTheme,
+    handleThemeToggle,
+  };
+}


### PR DESCRIPTION
Custom hook which provides theme toggling functionality using state values and functions:

- `darkThemeEnabled` state values tracking whether the theme is enabled.
- `applyTheme` a function to run in an effect to apply the theme set by the user or the system theme by default.
- `handleThemeToggle` a click handler to toggle the theme.

Fixes #12 